### PR TITLE
remove faq describing ironic

### DIFF
--- a/_faqs/what-is-ironic.md
+++ b/_faqs/what-is-ironic.md
@@ -1,4 +1,0 @@
----
-question: What is Ironic?
----
-Ironic is an OpenStack component that allows to provision and manage bare metal systems. Check the [Ironic documentation](https://github.com/metal3-io/metal3-docs/blob/master/design/use-ironic.md) for more details about Ironic usage in Metal³


### PR DESCRIPTION
Ironic is an implementation detail, and doesn't need to be mentioned
on the home page in the FAQ.