### PR TITLE
Video blogpost about the kni managed baremetal talk at Red Hat summit 2019

### DIFF
--- a/_includes/docs.md
+++ b/_includes/docs.md
@@ -26,7 +26,7 @@ The design documents for Metal3 are all publicly available. Refer to the [metal3
 
 - [Extend Your Data Center to the Hybrid Edge - Red Hat Summit, May 2019](https://www.pscp.tv/RedHatOfficial/1vAGRWYPjngJl?t=1h27m51s)
 - [OpenStack Ironic and Bare Metal Infrastructure: All Abstractions Start Somewhere - Chris Hoge, OpenStack Foundation; Julia Kreger, Red Hat]({% post_url 2019-10-31-OpenStack-Ironic-and-Bare-Metal-Infrastructure_All-Abstractions-Start-Somewhere %})
-- [Kubernetes-native Infrastructure: Managed Baremetal with Kubernetes Operators and OpenStack Ironic - Steve Hardy, Red Hat](https://sched.co/KMyE)
+- [Kubernetes-native Infrastructure: Managed Baremetal with Kubernetes Operators and OpenStack Ironic - Steve Hardy, Red Hat]({% post_url 2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic %})
 
 ### In The News
 

--- a/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
+++ b/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
@@ -6,13 +6,13 @@ categories: ["kubernetes", "metal3", "operator", "baremetal", "openstack", "iron
 author: Pedro Ibáñez Requena
 ---
 
-## Conference talk: Open Infraestructure Days UK 2019; Kubernetes-native Infrastructure: Managed Baremetal with Kubernetes Operators and OpenStack Ironic - Steve Hardy, Red Hat
+## Conference talk: Open Infrastructure Days UK 2019; Kubernetes-native Infrastructure: Managed Baremetal with Kubernetes Operators and OpenStack Ironic - Steve Hardy, Red Hat
 
-In this session you could hear about a new effort to enable baremetal Kubernetes deployments using native interfaces, and in particular the Kubernetes Operator framework, combined with OpenStack Ironic.
+In this session you can hear about a new effort to enable baremetal Kubernetes deployments using native interfaces, and in particular the Kubernetes Operator framework, combined with OpenStack Ironic.
 
 This approach aims to seamlessly integrate your infrastructure with your workloads, including baremetal servers, storage and container/VM workloads.  All this can be achieved using kubernetes native applications, combined with existing, proven deployment and storage tooling.
 
-I were covered the options around Kubernetes deployments today, the specific approach taken by the new Kubernetes-native "Metalkube" project, and the status/roadmap of this new community effort.
+In this talk we cover the options around Kubernetes deployments today, the specific approach taken by the new Kubernetes-native "Metalkube" project, and the status/roadmap of this new community effort.
 
 
 ## Speakers

--- a/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
+++ b/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
@@ -1,0 +1,24 @@
+---
+title: "Kubernetes-native Infrastructure: Managed Baremetal with Kubernetes Operators and OpenStack Ironic - Steve Hardy, Red Hat"
+date: 2019-11-07T13:02:00+02:00
+draft: false
+categories: ["kubernetes", "metal3", "operator", "baremetal", "openstack", "ironic"]
+author: Pedro Ibáñez Requena
+---
+
+## Conference talk: Open Infraestructure Days UK 2019; Kubernetes-native Infrastructure: Managed Baremetal with Kubernetes Operators and OpenStack Ironic - Steve Hardy, Red Hat
+
+In this session you could hear about a new effort to enable baremetal Kubernetes deployments using native interfaces, and in particular the Kubernetes Operator framework, combined with OpenStack Ironic.
+
+This approach aims to seamlessly integrate your infrastructure with your workloads, including baremetal servers, storage and container/VM workloads.  All this can be achieved using kubernetes native applications, combined with existing, proven deployment and storage tooling.
+
+I were covered the options around Kubernetes deployments today, the specific approach taken by the new Kubernetes-native "Metalkube" project, and the status/roadmap of this new community effort.
+
+
+## Speakers
+[Steve Hardy](https://twitter.com/hogepodge) is Senior Principal Software Engineer at Red Hat, currently involved in kubernetes/OpenShift deployment and architecture. He is also an active member of the OpenStack community, and has been a project team lead of both the Heat (orchestration) and TripleO (deployment) projects.
+
+
+## References
+
+* [Open Infrastructure Days UK 2019, Kubernetes-native Infrastructure: Managed Baremetal with Kubernetes Operators and OpenStack Ironic - Steve Hardy, Red Hat](https://openinfradays.sched.com/event/KMyE)

--- a/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
+++ b/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
@@ -16,7 +16,7 @@ I were covered the options around Kubernetes deployments today, the specific app
 
 
 ## Speakers
-[Steve Hardy](https://twitter.com/hogepodge) is Senior Principal Software Engineer at Red Hat, currently involved in kubernetes/OpenShift deployment and architecture. He is also an active member of the OpenStack community, and has been a project team lead of both the Heat (orchestration) and TripleO (deployment) projects.
+[Steve Hardy](https://github.com/hardys) is Senior Principal Software Engineer at Red Hat, currently involved in kubernetes/OpenShift deployment and architecture. He is also an active member of the OpenStack community, and has been a project team lead of both the Heat (orchestration) and TripleO (deployment) projects.
 
 
 ## References

--- a/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
+++ b/_posts/2019-11-07-Kubernetes-native_Infrastructure-Managed_Baremetal_with_Kubernetes_Operators_and_OpenStack_Ironic.md
@@ -16,7 +16,7 @@ In this talk we cover the options around Kubernetes deployments today, the speci
 
 
 ## Speakers
-[Steve Hardy](https://github.com/hardys) is Senior Principal Software Engineer at Red Hat, currently involved in kubernetes/OpenShift deployment and architecture. He is also an active member of the OpenStack community, and has been a project team lead of both the Heat (orchestration) and TripleO (deployment) projects.
+[Steve Hardy](http://hardysteven.blogspot.com) is Senior Principal Software Engineer at Red Hat, currently involved in kubernetes/OpenShift deployment and architecture. He is also an active member of the OpenStack community, and has been a project team lead of both the Heat (orchestration) and TripleO (deployment) projects.
 
 
 ## References


### PR DESCRIPTION
Converts the media link to that event in a blogpost as discussed in #73 


Preview at: https://deploy-preview-106--metal3.netlify.com/blog/2019/11/07/kubernetes-native_infrastructure-managed_baremetal_with_kubernetes_operators_and_openstack_ironic 