### PR TITLE
Replace docker by podman when building the web locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ We more than welcome contributions in the form of blog posts, pages and/or labs,
 
     ```console
     cd metal3-io.github.io
-    sudo docker run -d --name metal3io -p 4000:4000 -v $(pwd):/srv/jekyll:Z jekyll/jekyll jekyll serve --watch
+    mkdir .jekyll-cache
+    podman run -d --name kubevirtio -p 4000:4000 -v $(pwd):/srv/jekyll:Z jekyll/jekyll jekyll serve --future --watch
     ```
 
     **NOTE**: Be sure to cd into the *metal3-io.github.io* directory before running the above command as the Z at the end of the volume (-v) will relabel its contents so it can be written from within the container, like running `chcon -Rt svirt_sandbox_file_t -l s0:c1,c2` yourself.
@@ -23,7 +24,8 @@ We more than welcome contributions in the form of blog posts, pages and/or labs,
 
     ```console
     cd metal3-io.github.io
-    sudo docker run -d --name metal3io -p 4000:4000 -v $(pwd):/srv/jekyll jekyll/jekyll jekyll serve --watch
+    mkdir .jekyll-cache
+    sudo docker run -d --name metal3io -p 4000:4000 -v $(pwd):/srv/jekyll jekyll/jekyll jekyll serve --future --watch
     ```
 
 ### View the site


### PR DESCRIPTION
Signed-off-by: Alberto Losada <alosadag@redhat.com>

Change README.md detailing how to run the web locally by running a container using podman instead of docker