### PR TITLE
Update try-it based on PR#229 in metal3-dev-env

### DIFF
--- a/_includes/try-it.md
+++ b/_includes/try-it.md
@@ -263,6 +263,8 @@ Ubuntu 18.04 or Centos 7 target host images. Please make sure to meet [resourcer
 
 ```sh
 $ ./scripts/v1alphaX/provision_cluster.sh
+$ ./scripts/v1alphaX/provision_controlplane.sh
+$ ./scripts/v1alphaX/provision_worker.sh
 ```
 
 At this point, the `Machine` actuator will respond and try to claim a


### PR DESCRIPTION
There were some changes in [provisioning/deprovisioning](https://github.com/metal3-io/metal3-dev-env/tree/master/scripts/v1alphaX) scripts introduced with [PR#229](https://github.com/metal3-io/metal3-dev-env/pull/229). This patchset updates try-it accordingly.