### PR TITLE
Rename header reference from CAPBM to CAPM3

### DIFF
--- a/try-it.md
+++ b/try-it.md
@@ -17,7 +17,7 @@ permalink: /try-it.html
     - [Centos target hosts only, image update](#centos-target-hosts-only-image-update)
   - [Directly Provisioning Bare Metal Hosts](#directly-provisioning-bare-metal-hosts)
   - [Running Custom Baremetal-Operator](#running-custom-baremetal-operator)
-  - [Running Custom Cluster API Provider Baremetal](#running-custom-cluster-api-provider-baremetal)
+  - [Running Custom Cluster API Provider Metal3](#running-custom-cluster-api-provider-metal3)
   - [Accessing Ironic API](#accessing-ironic-api)
 
 <!-- /TOC -->
@@ -463,7 +463,7 @@ cd ~/go/src/github.com/metal3-io/baremetal-operator
 make run
 ```
 
-### Running Custom Cluster API Provider Baremetal
+### Running Custom Cluster API Provider Metal3
 
 There are two Cluster API related managers running in the cluster. One
 includes set of generic controllers, and the other includes a custom Machine


### PR DESCRIPTION
The rename in #153 forgot to update one header, only updating a reference to it from the table of contents, leaving the change half-done.

Then, #160 (57679b1) reverted the half-done part (i.e. the header reference), so undoing the part of the change that was already done.

This updates both the header and its reference to reflect the rename from Cluster API Provider Baremetal to Cluster API Provider Metal3.
