### PR TITLE
Point to yaspeller upstream repo for pre-commit plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: "^assets/js/"
 fail_fast: true
 repos:
 - repo: meta
@@ -7,7 +8,7 @@ repos:
   rev: 1.19.1
   hooks:
   - id: prettier
-    files: \.(md|markdown)
+    files: \.(css|js|md|markdown|json)
 - repo: https://github.com/openstack/bashate
   rev: 1.0.0
   hooks:
@@ -53,3 +54,8 @@ repos:
   rev:  master
   hooks:
   - id: blacken-docs
+- repo: https://github.com/hcodes/yaspeller.git
+  rev: master
+  hooks:
+  - id: yaspeller
+    types: [markdown]

--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -1,4 +1,8 @@
 {
+  "ignoreUrls": true,
+  "findRepeatWords": true,
+  "maxRequests": 5,
+  "ignoreDigits": true,
   "lang": "en",
   "dictionary": [
     "a VM",


### PR DESCRIPTION

Yaspeller got a PR merged so that it can be used directly.

This moves configuration to .yaspellerrc and makes pre-commit to check only markdown files in the commit

