### PR TITLE
Ignore 429 errors on html-proofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,8 @@ namespace :links do
             :empty_alt_ignore   => true,
             :url_swap           => {
                                     'https://metal3.io/' => '',
-                                    }
+                                    },
+            :http_status_ignore => [429],
         }
         puts "Checking External links..."
         HTMLProofer.check_directory("./_site", options).run


### PR DESCRIPTION
Ignores 429 errors on pages like github, etc that shouldn't be either fail or succeed 