### PR TITLE
Added K3_BINARIES_VERSION variable for version of kubeadm, kubectl and kubeadm

### DIFF
--- a/try-it.html
+++ b/try-it.html
@@ -501,6 +501,12 @@ can configure the following</p>
       <td>“x.x.x.x/x”</td>
       <td>“192.168.0.0/18”</td>
     </tr>
+    <tr>
+      <td>K3_BINARIES_VERSION=</td>
+      <td>Version of kubelet, kubeadm and kubectl</td>
+      <td>“x.x.x-xx” or “x.x.x”</td>
+      <td>“1.18.0”</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Adds a new variable `K3_BINARIES_VERSION` that determines the version of kubelet, kubectl and kubeadm.