### PR TITLE
add stbenjam and maelk as approvers for blog posts

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,7 +16,9 @@ filters:
     approvers:
       - dhellmann
       - hardys
+      - maelk
       - russellb
+      - stbenjam
 
   "^_(data|layouts|sass|css|js)/.*":
     labels:

--- a/OWNERS
+++ b/OWNERS
@@ -2,33 +2,33 @@
 filters:
   ".*":
     reviewers:
+      - alosadagrande
+      - dhellmann
+      - hardys
       - iranzo
       - knowncitizen
       - ptrnull
-      - dhellmann
-      - hardys
       - russellb
-      - alosadagrande
     approvers:
+      - alosadagrande
       - dhellmann
       - hardys
-      - russellb
       - iranzo
       - knowncitizen
       - ptrnull
-      - alosadagrande
+      - russellb
 
   "^_posts/.*":
     labels:
       - kind/blog
     reviewers:
-      - russellb
       - dhellmann
       - hardys
+      - russellb
     approvers:
-      - russellb
       - dhellmann
       - hardys
+      - russellb
 
   "^_(data|layouts|sass|css|js)/.*":
     labels:

--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 filters:
   ".*":
-    reviewers:
-      - alosadagrande
-      - dhellmann
-      - hardys
-      - iranzo
-      - knowncitizen
-      - ptrnull
-      - russellb
     approvers:
       - alosadagrande
       - dhellmann
@@ -21,10 +13,6 @@ filters:
   "^_posts/.*":
     labels:
       - kind/blog
-    reviewers:
-      - dhellmann
-      - hardys
-      - russellb
     approvers:
       - dhellmann
       - hardys
@@ -34,6 +22,4 @@ filters:
     labels:
       - kind/website
     approvers:
-      - matthewcarleton
-    reviewers:
       - matthewcarleton


### PR DESCRIPTION
Add Stephen and Maël, since both have reviewed content and are knowledgeable about the details needed to provide good reviews.

Also clean up the owners file

/cc @stbenjam @maelk