### PR TITLE
Update owners to reflect team changes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,12 +2,10 @@
 filters:
   ".*":
     approvers:
-      - alosadagrande
+      - codificat
       - dhellmann
       - hardys
-      - iranzo
       - knowncitizen
-      - ptrnull
       - russellb
 
   "^_posts/.*":


### PR DESCRIPTION
To  complement #183 : there have been some changes in the community team at RH and former website maintainers moved to another group.

For this change to work I should be part of the org (not there at the moment)
