### PR TITLE
Limit the number of blog posts highligted in the home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,6 @@ gem "html-proofer"
 
 # Rouge syntax hilighter
 gem "rouge"
+
+# Allow running 'rake', e.g. for local link checks
+gem "rake"

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ layout: default
     <a href="{{ site.baseurl }}/blog/index.html" class="mk-button mk-button--link">Blog</a>
 </header>
 <div class="mk-blog-meta__preview__scroll-wrapper">
-{% for post in site.posts %}
+{% for post in site.posts limit:3 %}
 <a href="{{ post.url }}" class="mk-blog-meta__snippet">
     <h3 class="mk-heading--lg mk-blog-meta__title">{{ post.title }}</h3>
     <time datetime="1999-12-23" class="mk-blog-meta__timestamp mk-blog-meta__item mk-blog-meta__timestamp--dark">{{ post.date | date: "%a, %-d/%m/%y" }}</time>


### PR DESCRIPTION
The current homepage side bar shows the whole list of blog posts under _"what's new?"_. This makes the page too long (and growing).

The PR limits that side bar's content to only the latest 3 blog posts.

Also adding `rake` to the Gemfile, which allows things like locally checking external links, e.g.
```sh
podman run --rm -i \
     --name linkcheck -v $(pwd):/srv/jekyll:Z jekyll/jekyll:latest \
     /bin/sh -c "bundle install && bundle exec rake links:test_external"
```