### PR TITLE
fix broken link and ignore twitter 400 error during ci testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ namespace :links do
             :log_level          => :info,
             :internal_domains   => ["https://instructor.labs.sysdeseng.com", "https://www.youtube.com"],
             :external_only      => true,
+            :url_ignore         => [ /http(s)?:\/\/(www.)?twitter.com.*/ ],
             :empty_alt_ignore   => true,
             :url_swap           => {
                                     'https://metal3.io/' => '',

--- a/_posts/2019-06-25-Metal3.md
+++ b/_posts/2019-06-25-Metal3.md
@@ -285,15 +285,7 @@ $ kubectl get machines my-node-0 -n openshift-machine-api -o jsonpath='{.metadat
 map[metal3.io/BareMetalHost:openshift-machine-api/my-node-0]
 ```
 
-The 1:1 relationship for the `Machine` and the `Node` currently requires to
-execute the [link-machine-and-node.sh](https://github.com/openshift-metal3/dev-scripts/blob/master/link-machine-and-node.sh) script to modify the `Machine`
-object `.status` field:
-
-```shell
-./link-machine-and-node.sh MACHINE NODE
-```
-
-Then, the reference is stored in the `.status.nodeRef.name` field in the
+The node reference is stored in the `.status.nodeRef.name` field in the
 `Machine` object:
 
 ```shell


### PR DESCRIPTION
Removed section from `Metal3` blog post which had a broken link, since its no longer relevant. And ignored twitter urls so that ci-testing doesn't break.