### PR TITLE
Update OWNERS to reflect team changes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,14 @@
 filters:
   ".*":
     approvers:
-      - codificat
       - dhellmann
       - hardys
+      - hroyrh
       - knowncitizen
       - russellb
+
+    emeritus_approvers:
+      - codificat       # 2021-03-03
 
   "^_posts/.*":
     labels:


### PR DESCRIPTION
Due to a job change I am not going to be active here for the time being, so this PR is to remove myself as an active approver in this repo.

@hroyrh will continue with tasks from my previous team, and that's why I'm adding him here as a replacement in the same change.

If it's preferred to just remove myself and follow the [process to add a new maintainer](https://github.com/metal3-io/metal3-docs/blob/master/maintainers/README.md) instead just let me know and I will limit the change to myself.

Thanks! :wave: 