### PR TITLE
 Update try-it guide to refer v1alpha4 instead of v1alpha3

### DIFF
--- a/_posts/2019-06-25-Metal3.md
+++ b/_posts/2019-06-25-Metal3.md
@@ -301,7 +301,7 @@ Being able to 'just scale a node' in k8s means a lot of underlying concepts and 
 ## Resources/links
 
 - <https://dzone.com/articles/introducing-the-kubernetes-cluster-api-project-2>
-- <https://blogs.vmware.com/cloudnative/2019/03/14/what-and-why-of-cluster-api/>
+- <https://tanzu.vmware.com/content/blog/the-what-and-the-why-of-the-cluster-api>
 - <https://github.com/kubernetes-sigs/cluster-api>
 - <https://github.com/kubernetes-sigs/cluster-api-provider-aws>
 - <https://itnext.io/deep-dive-to-cluster-api-a0b4e792d57d>


### PR DESCRIPTION
Changed mentions of v1alpha3 to v1alpha4 after verifying the scripts still work. Also fixed minor typos and added a short section about using the `config_user.sh` file