### PR TITLE
move maelk to emeritus_reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,7 @@ filters:
       - hroyrh
       - knowncitizen
       - russellb
-    
+
     reviewers:
       - fmuyassarov
 
@@ -18,7 +18,6 @@ filters:
       - kind/blog
     approvers:
       - hardys
-      - maelk
       - russellb
       - stbenjam
 
@@ -27,3 +26,6 @@ filters:
       - kind/website
     approvers:
       - matthewcarleton
+
+emeritus_approvers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.