### PR TITLE
Misc fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         types:
         - shell
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.10.0
+    rev: v1.12.1
     hooks:
     -   id: blacken-docs
 -   repo: https://github.com/hcodes/yaspeller.git

--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,5 @@ gem "rouge"
 
 # Allow running 'rake', e.g. for local link checks
 gem "rake"
+
+gem "webrick", "~> 1.7", :group => :development

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metal3.io Website
 
-[![Build Status](https://travis-ci.org/metal3-io/metal3-io.github.io.svg?branch=master)](https://travis-ci.org/metal3-io/metal3-io.github.io)
+[![Deploy via Jekyll on GitHub pages](https://github.com/metal3-io/metal3-io.github.io/actions/workflows/jekyll.yml/badge.svg?branch=source)](https://github.com/metal3-io/metal3-io.github.io/actions/workflows/jekyll.yml)
 
 ## Contributing contents
 
@@ -8,7 +8,7 @@ We more than welcome contributions in the form of blog posts, pages and/or labs,
 
 ## Test your changes in a local container
 
-### Run a jekyll container
+### Run a Jekyll container
 
 - On a SELinux enabled OS:
 
@@ -18,7 +18,7 @@ We more than welcome contributions in the form of blog posts, pages and/or labs,
   podman run -d --name metal3io -p 4000:4000 -v $(pwd):/srv/jekyll:Z jekyll/jekyll jekyll serve --future --watch
   ```
 
-  **NOTE**: Be sure to cd into the _metal3-io.github.io_ directory before running the above command as the Z at the end of the volume (-v) will relabel its contents so it can be written from within the container, like running `chcon -Rt svirt_sandbox_file_t -l s0:c1,c2` yourself.
+  **NOTE**: Make sure you are in the _metal3-io.github.io_ directory before running the above command as the Z at the end of the volume (-v) will relabel its contents so it can be written from within the container, like running `chcon -Rt svirt_sandbox_file_t -l s0:c1,c2` yourself.
 
 - On an OS without SELinux:
 

--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,6 @@ twitter_username: metal3_io
 github_username:  metal3-io
 type: website
 image: /assets/images/metal3logo.png
-highlighter: rouge
 
 # Build settings
 markdown: kramdown

--- a/documentation.html
+++ b/documentation.html
@@ -6,6 +6,7 @@ permalink: /documentation.html
 <div class="mk-masthead__content--sub">
         <h1 class="mk-masthead__content--sub__title">Documentation</h1>
         <p class="mk-masthead__content--sub__text">The Metal³ project (pronounced: Metal Kubed) exists to provide components that allow you to do bare metal host management for Kubernetes. Metal³ works as a Kubernetes application, meaning it runs on Kubernetes and is managed through Kubernetes interfaces.</p>
+        <p class="mk-masthead__content--sub__text">If you are looking for documentation about how to use Metal³, please check the <a href="https://metal3io.netlify.app/introduction.html">user-guide</a>.</p>
 </div>
 </section>
 <script>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@ layout: default
     <h1 class="mk-masthead__content__title">Metal<sup>3</sup></h1>
     <h3 class="mk-masthead__content__sub-title">Bare metal host provisioning for Kubernetes</h3>
     <a href="{{ site.baseurl }}/try-it.html" class="mk-button mk-button--primary">Get Started with Metal Kubed</a>
+    <a href="https://metal3io.netlify.app/introduction.html" class="mk-button mk-button--primary">Check out the user guide</a>
   </div>
 </section>
 <section class="mk-community-callout">


### PR DESCRIPTION
- Bump blacken-docs version (it was failing for me with the old version)
- Add link to the new user-guide
- Update build status badge
- Fix spelling
- Add `webrick` gem as development dependency (it is needed for `jekyll
serve` for some versions of Jekyll)
- Remove duplicate config for highlighter
