### PR TITLE
.github: secure github actions

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -6,11 +6,16 @@ on:
   # push:
   # ...
 
+permissions:
+  contents: read
+
 name: Broken Link Check
 jobs:
   check:
+    permissions:
+      issues: write
     name: Broken Link Check
     runs-on: ubuntu-latest
     steps:
       - name: Broken Link Check
-        uses: technote-space/broken-link-checker-action@v2
+        uses: technote-space/broken-link-checker-action@7820497a025fb09ff736ee11bb8bb12ca715b4fe # v2.3.1

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,21 +7,26 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   jekyll:
+    permissions:
+      deployments: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0
 
     # Use GitHub Actions' cache to shorten build times and decrease load on servers
-    - uses: actions/cache@v2.1.5
+    - uses: actions/cache@1a9e2138d905efd099035b49d8b7a3888c653ca8 # v2.1.5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - uses: iranzo/gh-pages-jekyll-action@1.0
+    - uses: iranzo/gh-pages-jekyll-action@d27999d323a83e1989f4b62f5176f0b4736066d3 # 1.0.2
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         SOURCE_FOLDER: ./


### PR DESCRIPTION
Set top-level permissions to read, only allowing write where necessary.

Pin actions by a sha.