### PR TITLE
fix jekyll permissions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,12 +7,12 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   jekyll:
     permissions:
+      contents: read
       deployments: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Jekyll has been unable to deploy pages for a while now, thanks to too tight permissions. This should fix the issue.