### PR TITLE
revert jekyll permissions changes

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,13 +7,8 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
-permissions: {}
-
 jobs:
   jekyll:
-    permissions:
-      contents: read
-      deployments: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2.6.0


### PR DESCRIPTION
Revert changes to Jekyll's permissions, and come back at them again when the deployment is working again.