### PR TITLE
update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     commit-message:
-        prefix: build
-        prefix-development: chore
-        include: scope
+      prefix: build
+      prefix-development: chore
+      include: scope
+    reviewers:
+      - "kashifest"
+      - "Rozzii"
+      - "tuminoid"


### PR DESCRIPTION
We don't have Python packages in the project -> drop the "pip" ecosystem.

Add default reviewers to "Github actions" ecosystem.
 - Rozzii is reviewer
 - kashifest is approver
 - tuminoid is security lead (which most of the uplifts are about)