### PR TITLE
update user-guide url

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -7,5 +7,5 @@ Please do:
 
 In this repository security reports are handled according to the
 Metal3-io project's security policy. For more information about the security
-policy consult the User-Guide [here](https://metal3io.netlify.app/security_policy.html).
+policy consult the User-Guide [here](https://book.metal3.io/security_policy.html).
 

--- a/documentation.html
+++ b/documentation.html
@@ -6,7 +6,7 @@ permalink: /documentation.html
 <div class="mk-masthead__content--sub">
         <h1 class="mk-masthead__content--sub__title">Documentation</h1>
         <p class="mk-masthead__content--sub__text">The Metal³ project (pronounced: Metal Kubed) exists to provide components that allow you to do bare metal host management for Kubernetes. Metal³ works as a Kubernetes application, meaning it runs on Kubernetes and is managed through Kubernetes interfaces.</p>
-        <p class="mk-masthead__content--sub__text">If you are looking for documentation about how to use Metal³, please check the <a href="https://metal3io.netlify.app/introduction.html">user-guide</a>.</p>
+        <p class="mk-masthead__content--sub__text">If you are looking for documentation about how to use Metal³, please check the <a href="https://book.metal3.io/introduction.html">user-guide</a>.</p>
 </div>
 </section>
 <script>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: default
     <h1 class="mk-masthead__content__title">Metal<sup>3</sup></h1>
     <h3 class="mk-masthead__content__sub-title">Bare metal host provisioning for Kubernetes</h3>
     <a href="{{ site.baseurl }}/try-it.html" class="mk-button mk-button--primary">Get Started with Metal Kubed</a>
-    <a href="https://metal3io.netlify.app/introduction.html" class="mk-button mk-button--primary">Check out the user guide</a>
+    <a href="https://book.metal3.io/introduction.html" class="mk-button mk-button--primary">Check out the user guide</a>
   </div>
 </section>
 <section class="mk-community-callout">


### PR DESCRIPTION
Our user-guide is now properly hosted at https://book.metal3.io/