### PR TITLE
fix sass -> scss in owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -20,6 +20,7 @@ filters:
   "^_posts/.*":
     labels:
       - kind/blog
+
     approvers:
       - hroyrh
       - lentzi90
@@ -33,9 +34,10 @@ filters:
       - hardys
       - stbenjam
 
-  "^_(data|layouts|sass|css|js)/.*":
+  "^_(data|layouts|scss|css|js)/.*":
     labels:
       - kind/website
+
     approvers:
       - hroyrh
       - lentzi90


### PR DESCRIPTION
Files like `_header.scss` did not match the CSS pattern in owners due typo.

Noticed in PR #289 .