### PR TITLE
Fix trailing whitespace

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,7 @@
       <p>Copyright {{ 'now' | date: "%Y" }} The Metal³ Contributors - <a href="/privacy-statement.html">Privacy Statement</a></p>
       <p>Copyright {{ 'now' | date: "%Y" }} The Linux Foundation. All Rights Reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page.</p>
     </div>
-   
+
   </div>
 </footer>
 </div><!--wrapper-->


### PR DESCRIPTION
#346 was opened before the pre-commit status check was added, so it wasn't properly checked. This PR fixes a trailing whitespace that was introduced as a consequence.