### PR TITLE
improve pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,10 +5,14 @@ on:
   push:
     branches: [source]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
+    if: github.repository == 'metal3-io/metal3-io.github.io'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-    - uses: actions/setup-python@v4
-    - uses: pre-commit/action@v3.0.0
+    - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0


### PR DESCRIPTION
Add default permissions, and also prevent it from running in forks, same as other workflows.

Pin two remaining actions to SHA digests.