### PR TITLE
run dependabot less often

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
     reviewers:
       - "lentzi90"
       - "Rozzii"
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: build
       prefix-development: chore


### PR DESCRIPTION
Running dependabot daily is excessive. Change `daily` to `weekly` for NPM and `monthly` to GH actions. Security updates will ignore these schedules anyways.