### PR TITLE
add if: repository check to workflows

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,21 +1,22 @@
 on:
   schedule:
-    - cron: "0 0 * * *" # daily
+  - cron: "0 0 * * *"
   repository_dispatch: # run manually
     types: [check-link]
-  # push:
-  # ...
 
-permissions:
-  contents: read
+permissions: {}
 
 name: Broken Link Check
 jobs:
   check:
-    permissions:
-      issues: write
     name: Broken Link Check
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    if: github.repository == 'metal3-io/metal3-io.github.io'
     steps:
-      - name: Broken Link Check
-        uses: technote-space/broken-link-checker-action@b8332d945b97f8b52eb8d7d889a1e0e37106c1a9 # v2.3.2
+    - name: Broken Link Check
+      uses: technote-space/broken-link-checker-action@b8332d945b97f8b52eb8d7d889a1e0e37106c1a9 # v2.3.2

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,19 +1,22 @@
-name: Deploy via Jekyll on GitHub  pages
+name: Deploy via Jekyll on GitHub pages
 
 on:
   push:
     branches:
-      - source
+    - source
   schedule:
-    - cron:  '0 0 * * *'
+  - cron: '0 0 * * *'
+
+# TODO: permissions defined
 
 jobs:
   jekyll:
     runs-on: ubuntu-latest
+
+    if: github.repository == 'metal3-io/metal3-io.github.io'
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
-    # Use GitHub Actions' cache to shorten build times and decrease load on servers
     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: vendor/bundle


### PR DESCRIPTION
Don't run broken link checker nor deploy workflows on forks.