### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- elfosardo
-- hroyrh
-- lentzi90
+- metal3-io-github-io-maintainers
 
 reviewers:
-- kashifest
-- Rozzii
-- tuminoid
+- metal3-io-github-io-maintainers
+- metal3-io-github-io-reviewers
 
 emeritus_approvers:
 - codificat

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  metal3-io-github-io-maintainers:
+  - elfosardo
+  - hroyrh
+  - lentzi90
+
+  metal3-io-github-io-reviewers:
+  - kashifest
+  - Rozzii
+  - tuminoid


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.