### PR TITLE
Add Makefile for linting and serving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+CONTAINER_RUNTIME ?= $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
+IMAGE_NAME ?= ruby
+IMAGE_TAG ?= bullseye
+HOST_PORT ?= 4000
+
+.PHONY: serve
+serve: # Serve the website on localhost:3000
+	$(CONTAINER_RUNTIME) run \
+	--rm -it --name metal3-io \
+	-w /srv/jekyll \
+	-v "$$(pwd):/srv/jekyll:Z" \
+	-p $(HOST_PORT):4000 \
+	$(IMAGE_NAME):$(IMAGE_TAG) \
+	sh -c "bundle install && bundle exec jekyll serve --future --watch --host 0.0.0.0 --port $(HOST_PORT)"
+
+## ------------------------------------
+## Linting and testing
+## ------------------------------------
+
+.PHONY: lint
+lint: markdownlint spellcheck shellcheck pre-commit # Run all linting tools
+
+.PHONY: markdownlint
+markdownlint: # Run markdownlint
+	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) ./hack/markdownlint.sh
+
+.PHONY: spellcheck
+spellcheck: # Run spellcheck
+	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) ./hack/spellcheck.sh
+
+.PHONY: shellcheck
+shellcheck: # Run shellcheck
+	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) ./hack/shellcheck.sh
+
+.PHONY: pre-commit
+pre-commit: # Run pre-commit hooks
+	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) ./hack/pre-commit.sh

--- a/README.md
+++ b/README.md
@@ -12,29 +12,16 @@ with our content! [Here's our guideline for content](GUIDELINES.md).
 
 ### Run a Jekyll container
 
-- On an SELinux-enabled OS:
+You can run a local container with the Metal3.io website using Docker or
+Podman.
 
-  ```console
-  cd metal3-io.github.io
-  mkdir .jekyll-cache
-  podman run -d --name metal3io -p 4000:4000 \
-    -v $(pwd):/srv/jekyll:Z jekyll/jekyll jekyll serve --future --watch
-  ```
-
-  **NOTE**: Make sure you are in the _metal3-io.github.io_ directory
-  before running the above command as the Z at the end of the volume
-  (-v) will relabel its contents so it can be written from within the
-  container, like running `chcon -Rt svirt_sandbox_file_t -l s0:c1,c2`
-  yourself.
-
-- On an OS without SELinux:
-
-  ```console
-  cd metal3-io.github.io
-  mkdir .jekyll-cache
-  sudo docker run -d --name metal3io -p 4000:4000 \
-    -v $(pwd):/srv/jekyll jekyll/jekyll jekyll serve --future --watch
-  ```
+```bash
+cd metal3-io.github.io
+# For Podman:
+make serve
+# alternatively, if you want to use Docker:
+CONTAINER_RUNTIME=docker make serve
+```
 
 ### View the site
 

--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    git config --global --add safe.directory /workdir
+    pip install pre-commit
+    pre-commit run --all-files
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/python:3.12.3-bullseye@sha256:82e37316cd3f0e9c696bb9428df38a2e39a9286ee864286f8285185b685b60ee \
+        /workdir/hack/pre-commit.sh "$@"
+fi


### PR DESCRIPTION
The Makefile contains targets for linting for serving the website
locally.
This commit also adds a hack script for running pre-commit similar to
markdownlint, shellcheck and spellcheck. Now all of them can be run with
a simple `make lint` as long as podman or docker is available.

The README.md is also update to make use of the make serve command. The
image that was used in the readme no longer works with the versions we
are using.