### PR TITLE
Add more approvers and reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,11 +2,17 @@
 
 aliases:
   metal3-io-github-io-maintainers:
+  - dtantsur
   - elfosardo
   - hroyrh
+  - kashifest
   - lentzi90
+  - Rozzii
+  - zaneb
 
   metal3-io-github-io-reviewers:
-  - kashifest
-  - Rozzii
+  - adilGhaffarDev
+  - mboukhalfa
+  - mquhuy
+  - smoshiur1237
   - tuminoid


### PR DESCRIPTION
This repository does not see much traffic so these changes are mainly based on contributions elsewhere (e.g. metal3-docs that has similar content).

Approvers as agreed over email. I also added some reviewers based on commits in this repo and presence in metal3-docs.
/cc @elfosardo @hroyrh 