### PR TITLE
run broken link checker once a week

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 0 * * 0"
   repository_dispatch: # run manually
     types: [check-link]
 


### PR DESCRIPTION
There is no need to run it daily, especially with the amount of flakes it produces these days. I will replace this with better checker later on.