### PR TITLE
fix spellcheck glob

### DIFF
--- a/hack/spellcheck.sh
+++ b/hack/spellcheck.sh
@@ -20,7 +20,7 @@ WORKDIR="${WORKDIR:-/workdir}"
 
 # all md files, but ignore .github and node_modules
 if [ "${IS_CONTAINER}" != "false" ]; then
-    cspell-cli --show-suggestions -c .cspell-config.json -- ./**/*.md
+    cspell-cli --show-suggestions -c .cspell-config.json -- "./**/*.md"
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \


### PR DESCRIPTION
Since we're running the check in sh, it does not have globstar option to handle '**/*.md' properly. It only checked exactly one level deep markdown files. Spellcheck handles globs itself, so just adding quotes is enough to fix it.

In this repo, it only ignored top-level ones, which luckily do not have any spellcheck issues, so it is enough to just fix the glob.