### PR TITLE
🌱 Change link checker to lychee

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
   - cron: "0 0 * * 0"
   repository_dispatch: # run manually
@@ -16,7 +17,26 @@ jobs:
       contents: read
       issues: write
 
-    if: github.repository == 'metal3-io/metal3-io.github.io'
     steps:
-    - name: Broken Link Check
-      uses: technote-space/broken-link-checker-action@b8332d945b97f8b52eb8d7d889a1e0e37106c1a9 # v2.3.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Read URLs From Sitemap
+        id: extract
+        run: echo "urls=$(curl -sL https://metal3.io/sitemap.xml |  grep -o "<loc>[^<]*" | sed -e 's/<[^>]*>//g' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Link Checker Metal3.io Web Page
+        id: lycheemetal3io
+        uses: lycheeverse/lychee-action@f81112d0d2814ded911bd23e3beaa9dda9093915 # v2.1.0
+        with:
+          args: --user-agent "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0" ${{ steps.extract.outputs.urls }}
+          output: /tmp/lychee_output.md
+          fail: false
+
+      - name: Create Issue From File Metal3.io
+        if: steps.lycheemetal3io.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        with:
+          title: Link Checker Report
+          content-filepath: /tmp/lychee_output.md
+          labels: |
+            kind/bug

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+https://localhost
+http://localhost
+https://0.0.0.0
+http://0.0.0.0
+https://github.com/issues


### PR DESCRIPTION
Current Broken-link-checker is not actually checking in the https://metal3.io/ webpage. It is causing a lot of flakes like this: 
https://github.com/metal3-io/metal3-io.github.io/issues/448 
https://github.com/metal3-io/metal3-io.github.io/issues/485 

In current link checker no URL is specified so it uses the default https://github.com/${{ github.repository }}{}. This means we are checking links in the site https://github.com/metal3-io/metal3-io.github.io instead of the intended https://metal3.io/ . To check all pages in a site we should serve a sitemap.xml as input to be checked. 

I also think workflow should move to use lychee
https://lychee.cli.rs/introduction/#check-all-links-on-a-website
https://github.com/lycheeverse/lychee-action

Lychee is better documented, has active maintainers and widely adopted. Here is a workflow for that. 

I've tested this code in my own fork. It creates quite nice reports and issues:
https://github.com/peppi-lotta/metal3-io.github.io/actions/runs/11834513843/job/32975333756
https://github.com/peppi-lotta/metal3-io.github.io/issues/27