### PR TITLE
fix: openshift cluster-api controller machine broken link

### DIFF
--- a/_posts/2019-06-25-Metal3.md
+++ b/_posts/2019-06-25-Metal3.md
@@ -180,7 +180,7 @@ The [machine-api-operator](https://github.com/openshift/machine-api-operator) is
 an operator that manages the Machine API objects in an OpenShift 4 cluster.
 
 The operator is capable of creating machines in AWS and libvirt (more providers
-coming soon) via the [`Machine Controller`](https://github.com/openshift/cluster-api/tree/master/pkg/controller/machine) and it is included out of the
+coming soon) via the [`Machine Controller`](https://github.com/openshift/cluster-api/tree/master/internal/controllers/machine) and it is included out of the
 box with OCP 4 (and [can be deployed in a k8s vanilla as well](https://github.com/openshift/machine-api-operator#dev))
 
 ## Baremetal


### PR DESCRIPTION
Signed-off-by: lekaf974 <matthieu.evrin@gmail.com>

Fix #523 