### PR TITLE
group dependabot action bumps into one pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
   schedule:
     interval: "monthly"
   target-branch: source
+  ## group all action bumps into single PR
+  groups:
+    all-github-actions:
+      patterns: ["*"]
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
Group dependabot action bumps into one PR, like in other repos.