### PR TITLE
fix broken link to cluster-apis tilt doc

### DIFF
--- a/_posts/2024-05-30-Scaling_part_3.md
+++ b/_posts/2024-05-30-Scaling_part_3.md
@@ -69,8 +69,8 @@ resource usage. The Kubeadm control plane controller was [unreasonably CPU
 hungry](https://github.com/kubernetes-sigs/cluster-api/issues/8602)!
 
 Luckily, Cluster API has excellent [debugging and monitoring tools
-available](https://cluster-api.sigs.k8s.io/developer/tilt) so it was easy to
-collect data and profile the controllers. A quick look at the dashboard
+available](https://cluster-api.sigs.k8s.io/developer/core/tilt) so it was easy
+to collect data and profile the controllers. A quick look at the dashboard
 confirmed that the Kubeadm control plane controller was indeed the culprit, with
 a CPU usage far higher than the other controllers.
 


### PR DESCRIPTION
Fix broken link to CAPI's tilt documentation.

Fixes: #547 