### PR TITLE
remove bump restrictions from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,11 +20,5 @@ updates:
   groups:
     github-actions:
       patterns: ["*"]
-  ignore:
-  # Ignore major bumps in main, as it breaks the group bump process
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major"]
-  commit-message:
-    prefix: ":seedling:"
   labels:
   - "ok-to-test"


### PR DESCRIPTION
In this repo, we don't have that many workflows to be bumped that we could not allow bumping majors, unlike in BMO or some other repos where we depend largely on the workflows.