### PR TITLE
update zoom link on contributor page

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -23,7 +23,7 @@ title: Contribute
 <ul class="mk-social-list">
 <li>Familiarize yourself with the <a href="https://github.com/orgs/metal3-io/repositories">Metal<sup>3</sup> repositories</a> on GitHub.</li>
 <li>Follow the documentation to set up your <a href="https://book.metal3.io/developer_environment/tryit.html">development environment</a>. This will allow you to test your changes locally before submitting them.</li>
-<li>Join <a href="https://zoom.us/j/97255696401?pwd=ZlJMckNFLzdxMDNZN2xvTW5oa2lCZz09">community calls</a> and <a href="https://groups.google.com/g/metal3-dev">mailing list</a> to engage in discussions with the members of the metal3 community.</li>
+<li>Join <a href="https://zoom-lfx.platform.linuxfoundation.org/meeting/93558879994?password=ddd21dc3-ea2f-433f-8c93-fae1a5bb187d">community meetings</a> and <a href="https://groups.google.com/g/metal3-dev">mailing list</a> to engage in discussions with the members of the metal3 community.</li>
 <li>Join <a href="https://docs.openstack.org/ironic/latest/contributor/contributing.html">Ironic Community</a> for steps on how to contribute.</li>
 <li>Check out <a href="/community-resources.html">community resources</a> page to find out more.</li><br>
 <header class="mk-main__header">


### PR DESCRIPTION
This PR:
 - Updates the zoom link in the contribute.html

This commit is needed because now the community started to manage the zoom meeting via LFX Project Control Center and the old link is not relevant anymore.