### PR TITLE
lint: allow long lines in tables and code fences

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,9 @@ config:
   ul-indent:
     # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
     indent: 3
+  line-length:
+    tables: false
+    code_blocks: false
 
 # Don't autofix anything, we're linting here
 fix: false

--- a/_includes/docs.md
+++ b/_includes/docs.md
@@ -13,7 +13,6 @@
 
 - [The New Stack: Metal3 Uses OpenStack's Ironic for Declarative Bare Metal Kubernetes]({% post_url 2019-05-13-The_new_stack_Metal3_Uses_OpenStack_Ironic_for_Declarative_Bare_Metal_Kubernetes %})
 - [The Register: Raise some horns: Red Hat's MetalKube aims to make Kubernetes on bare machines simple]({% post_url 2019-04-12-Raise_some_horns_Red_Hat_s_MetalKube_aims_to_make_Kubernetes_on_bare_machines_simple %})
-
 <!-- markdownlint-enable MD013 -->
 
 ### Blog Posts

--- a/_posts/2019-04-12-Raise_some_horns_Red_Hat_s_MetalKube_aims_to_make_Kubernetes_on_bare_machines_simple.md
+++ b/_posts/2019-04-12-Raise_some_horns_Red_Hat_s_MetalKube_aims_to_make_Kubernetes_on_bare_machines_simple.md
@@ -16,11 +16,7 @@ categories:
 author: Pedro Ibáñez Requena
 ---
 
-<!-- markdownlint-disable MD013 -->
-
 ## The Register; Raise some horns: Red Hat's Metal³ aims to make Kubernetes on bare machines simple
-
-<!-- markdownlint-enable MD013 -->
 
 [Max Smolaks](https://www.theregister.com/Author/Max-Smolaks) talks in
 this article about the OpenInfra Days in the UK, 2019: where Metal³ was

--- a/_posts/2020-06-18-Metal3-dev-env-BareMetal-Cluster-Deployment.md
+++ b/_posts/2020-06-18-Metal3-dev-env-BareMetal-Cluster-Deployment.md
@@ -58,8 +58,6 @@ first and then revisit this.
 A description of some of the files part of provisioning a cluster, in a
 centos-based environment:
 
-<!-- markdownlint-disable MD013 -->
-
 | Name                                                                                                                                            | Description                                                                       | Path                                                                                  |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | provisioning scripts                                                                                                                            | Scripts to trigger provisioning of cluster, control plane or worker               | `${metal3-dev-env}/scripts/provision/`                                                |
@@ -82,8 +80,6 @@ Here are some of the resources that are created as part of provisioning :
 | Metal3Machine         | Corresponding Metal3 resource for managing bare metal nodes, it's managed by a `Machine` resource                                                                                              |
 | Metal3MachineTemplate | Metal3 resource which acts as a template when creating a control plane or a worker node                                                                                                        |
 | KubeadmConfigTemplate | A template of `KubeadmConfig`, for Workers, used to generate KubeadmConfig when a new worker node is provisioned                                                                               |
-
-<!-- markdownlint-enable MD013 -->
 
 > note "Note"
 > The corresponding `KubeadmConfig` is copied to the control
@@ -459,11 +455,11 @@ sh ${metal3-dev-env-path}/scripts/deprovision/cluster.sh
 The following video demonstrates all the steps to provision and
 de-provision a Kubernetes cluster explained above.
 
-<!-- markdownlint-disable MD033 MD013 -->
+<!-- markdownlint-disable MD033 -->
 
 <iframe width="1110" height="625" style="height: 625px" src="https://www.youtube.com/embed/FzDQs_9XvtU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<!-- markdownlint-enable MD033 MD013 -->
+<!-- markdownlint-enable MD033 -->
 
 ## Summary
 

--- a/_posts/2022-07-08-One_cluster_multiple_providers.md
+++ b/_posts/2022-07-08-One_cluster_multiple_providers.md
@@ -110,8 +110,6 @@ just need to run the BYOH agent in the VM to make it register as a
 ByoHost in the management cluster. The BYOH agent needs a kubeconfig
 file to do this, so we start by copying it to the VM:
 
-<!-- markdownlint-disable MD013 -->
-
 ```bash
 {%- comment -%}
 Raw is needed to escape the double curly braces.
@@ -126,11 +124,7 @@ scp -i .vagrant/machines/control-plane1/libvirt/private_key \
 {% endraw %}
 ```
 
-<!-- markdownlint-enable MD013 -->
-
 Next, install the prerequisites and host agent in the VM and run it.
-
-<!-- markdownlint-enable MD013 -->
 
 ```bash
 vagrant ssh
@@ -140,8 +134,6 @@ mv byoh-hostagent-linux-amd64 byoh-hostagent
 chmod +x byoh-hostagent
 sudo ./byoh-hostagent --namespace metal3 --kubeconfig management-cluster.conf
 ```
-
-<!-- markdownlint-disable MD013 -->
 
 You should now have a management cluster with both the Metal³ and BYOH
 providers installed, as well as two BareMetalHosts and one ByoHost.


### PR DESCRIPTION
Allow lines longer than 80 chars, if they're in tables or code fences. In those, long lines cannot often be avoided, and ignoring them one by one is painful and not pretty.

The same change is applied to all repos with markdownlint, but only on main. Documentation is 99% of the time maintained only in main, so it doesn't matter in release branches.