### PR TITLE
render posts dated in future for netlify preview

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,5 @@
 desc 'Generate HTML of metal3.io'
 task :default do
     puts "Building"
-    sh "bundle exec jekyll build"
+    sh "bundle exec jekyll build --future"
 end


### PR DESCRIPTION
This will make Netlify previews render posts from future dates, same as local serving option. It is quite often that we have posts planned for some date (in future) and struggle to preview, making reviewing more painful it needs to be.