### PR TITLE
harden github actions workflows

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -16,6 +16,8 @@ jobs:
     if: github.repository == 'metal3-io/metal3-io.github.io'
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -5,7 +5,7 @@
 name: Approve GH Workflows
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [edited, labeled, reopened, synchronize]
 
 permissions: {}

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   check-pr-links:
-    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main
+    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main # zizmor: ignore[unpinned-uses]
     with:
       upstream: https://github.com/metal3-io/metal3-io.github.io.git

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,5 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   check-links:
-    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main
+    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,6 +10,6 @@ on:
 jobs:
   yamllint-check:
     name: yaml-lint
-    uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main
+    uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Add persist-credentials: false to checkout actions and suppress accepted zizmor findings with inline comments.

NOTE: Jekyll is still missing permissions. That will be done in separate PR as we've tried finding correct permissions before and then it failed and had to be reverted.