### PR TITLE
fix jekyll permissions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -7,10 +7,12 @@ on:
   schedule:
   - cron: '0 0 * * *'
 
-# TODO: permissions defined
+permissions: {}
 
 jobs:
   jekyll:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     if: github.repository == 'metal3-io/metal3-io.github.io'


### PR DESCRIPTION
Jekyll force-pushed into master so it needs contents: write instead of deployments: write we tried earlier. Merging this allows turning off the repo level default write permissions for workflows.