### PR TITLE
fix: escape Liquid syntax in OCI/IPA deploy post

### DIFF
--- a/.cspell-config.json
+++ b/.cspell-config.json
@@ -104,6 +104,7 @@
     "Eduardo",
     "EKS",
     "endpoint",
+    "endraw",
     "entrypoint",
     "env",
     "epel",

--- a/_posts/2026-02-01-Deploying_OCI_Images_with_Custom_IPA_Hardware_Manager.md
+++ b/_posts/2026-02-01-Deploying_OCI_Images_with_Custom_IPA_Hardware_Manager.md
@@ -1757,6 +1757,8 @@ def extract_oci_image(image, platform, dest_dir):
 
 Installs cloud-init, GRUB, kernel, and other required packages via apt.
 
+{% raw %}
+
 ```python
 def install_packages(chroot_dir, grub_packages):
     """Install required packages in chroot.
@@ -1884,6 +1886,8 @@ def install_packages(chroot_dir, grub_packages):
 
     LOG.info("Package installation complete")
 ```
+
+{% endraw %}
 
 </details>
 


### PR DESCRIPTION
## Summary

- Escape the {{print $1}} awk snippet in the Python f-string code block so Jekyll/Liquid does not try to parse it as a template expression, fixing the deployment warning.

Closes #618 