### PR TITLE
Fix broken OpenStack network data format link

### DIFF
--- a/_faqs/network-configuration.md
+++ b/_faqs/network-configuration.md
@@ -3,4 +3,4 @@ question: How can one supply network configuration during provisioning?
 ---
 
 You can put it to the BareMetalHost's network Data field in the
-[OpenStack network data format](https://docs.openstack.org/nova/latest/_downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json).
+[OpenStack network data format](https://docs.openstack.org/nova/latest/_downloads/4e8fe1ae7db6dd6eebca372db68fe63e/network_data.json).


### PR DESCRIPTION
### Fix broken link in network-configuration FAQ

The link checker reported a 404 on the OpenStack network data format URL in _faqs/network-configuration.md. The broken URL pointed to a hashed .json download path on the OpenStack docs site, which changes whenever the docs are rebuilt, making it inherently fragile.

Replaced the broken URL with a stable link to the OpenStack metadata HTML documentation page.

Fixes: broken link reported in _faqs/network-configuration.md
Changed: _downloads/9119ca7ac90aa2990e762c08baea3a36/network_data.json → user/metadata.html#network-data``

Closes #630